### PR TITLE
Fix to vanilla URLs for when laravel is not at root

### DIFF
--- a/src/boot/helpers.php
+++ b/src/boot/helpers.php
@@ -26,3 +26,15 @@ function LogException(\Exception $ex)
 {
     echo \App::make('exception')->handleException($ex);
 }
+
+
+/**
+ * Use Laravel's routing instead of Vanilla's. This allows the vanilla integration
+ * to function properly even if the laravel application is in a subdirectory and 
+ * not hosted at the root of the the web server
+ */
+if (class_exists('Url')) {
+	function SmartAsset($Destination = '', $WithDomain = FALSE, $AddVersion = FALSE) {		
+		return \Url::to($Destination);
+	}
+}

--- a/src/services/GardenRequest.php
+++ b/src/services/GardenRequest.php
@@ -14,6 +14,15 @@ class GardenRequest extends \Gdn_Request
     {
         return forum_get_route_prefix();
     }
+	
+	/**
+     * Use Laravel's routing instead of Vanilla's. This allows the vanilla integration
+	 * to function properly even if the laravel application is in a subdirectory and 
+	 * not hosted at the root of the the web server
+     */
+	public function Url($Path = '', $WithDomain = FALSE, $SSL = NULL) {
+		return \URL::to($Path);		
+	}
 
     /**
      * Some machinery to play nice with Vanilla's Garden Framework IOC.

--- a/src/services/GardenRequest.php
+++ b/src/services/GardenRequest.php
@@ -8,11 +8,23 @@ namespace BishopB\Forum;
 class GardenRequest extends \Gdn_Request
 {
     /**
-     * We specifically always want our web root inside our route.
+     * Use Laravel's routing instead of Vanilla's. This allows the vanilla integration
+	 * to function properly even if the laravel application is in a subdirectory and 
+	 * not hosted at the root of the the web server
      */
     public function WebRoot($WebRoot = NULL)
     {
-        return forum_get_route_prefix();
+    	$full_url = \URL::to('/');
+		
+		//Remove the domain (http://www.example.com/) to create the the WebRoot that 
+		//Vanilla needs
+		$pos1 = strpos($full_url, '/');
+		$pos2 = strpos($full_url, '/', $pos1 + strlen('/'));
+		$pos3 = strpos($full_url, '/', $pos2 + strlen('/'));
+					
+    	$webroot = substr($full_url,$pos3);
+    	
+        return $webroot;
     }
 	
 	/**


### PR DESCRIPTION
There is currently a bug with the laravel-forums if the base Laravel application is hosted in a sub-directory such as http://localhost/ncpop/public instead of http://localhost. This fix changes Vanilla's Request URL handling to be handled instead by Laravel's URL::to() function so Laravel does all the heavy lifting in determining the proper route and better handles situations where Laravel isn't at the root of the web server.
